### PR TITLE
Add clear contributor-friendly test and validation command examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,14 @@ python keyquest.pyw
 Common validation commands:
 
 ```powershell
+# Check code quality
 ruff check .
+
+# Run tests
 pytest -q
+
+# Run both before opening a PR
+ruff check . && pytest -q
 ```
 
 ## Accessibility Expectations

--- a/docs/dev/DEVELOPER_SETUP.md
+++ b/docs/dev/DEVELOPER_SETUP.md
@@ -16,6 +16,31 @@
 
 - `py -3.9 keyquest.pyw`
 
+## Common Development Commands
+
+Here are the commands you'll need most often as a contributor:
+
+### Run the application
+```powershell
+py -3.9 keyquest.pyw
+```
+
+### Run linting (code quality check)
+```powershell
+ruff check .
+```
+
+### Run tests
+```powershell
+pytest -q
+```
+
+### Run both before submitting a PR
+```powershell
+ruff check .
+pytest -q
+```
+
 Notes:
 - On Windows, screen reader support uses `cytolk` (Tolk). If it is not installed/available, KeyQuest falls back to `pyttsx3`.
 - `keyquest.pyw` attempts to relaunch itself with Python 3.9 if Windows opens it with a different interpreter.


### PR DESCRIPTION
## Summary
Add clearer test and validation command examples to the contributor documentation.

## Changes
- Added 'Common Development Commands' section to `docs/dev/DEVELOPER_SETUP.md` with clear examples for running the app, linting, and tests
- Enhanced `CONTRIBUTING.md` with explanatory comments for each command
- Added combined command example for running both checks before PRs

## Why
New contributors should be able to discover the common local commands quickly without reading through multiple files.

## Definition of done
- [x] The main contributor docs show the common commands clearly
- [x] A new contributor can tell how to run lint, tests, and the app from the docs alone

Fixes: csm120/KeyQuest#5