### PR TITLE
docs: add quick command reference to contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,41 @@ KeyQuest is a Windows typing game built with Python, with a strong focus on keyb
 
 KeyQuest currently targets Python 3.9.
 
+### Quick Command Reference
+
+**Setup and run:**
+```powershell
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python keyquest.pyw
+```
+
+**Validation and testing:**
+```powershell
+# Lint code style
+ruff check .
+
+# Run tests
+pytest -q
+
+# Auto-fix lint issues
+ruff check . --fix
+```
+
+**Building and packaging:**
+```powershell
+# Build executable (.exe)
+tools\build\build_exe.bat
+
+# Build installer
+tools\build\build_installer.bat
+
+# Full release (version bump + tag + publish)
+powershell -ExecutionPolicy Bypass -File tools/ship_updates.ps1
+```
+
+### Detailed Setup
+
 Basic local setup:
 
 ```powershell

--- a/docs/dev/DEVELOPER_SETUP.md
+++ b/docs/dev/DEVELOPER_SETUP.md
@@ -1,5 +1,34 @@
 # KeyQuest Developer Setup (Windows)
 
+## Quick Command Reference
+
+**Essential commands for contributors:**
+
+```powershell
+# Install dependencies
+pip install -r requirements.txt
+
+# Run the app
+py -3.9 keyquest.pyw
+
+# Check code style (lint)
+ruff check .
+
+# Run tests
+pytest -q
+
+# Auto-fix lint issues
+ruff check . --fix
+
+# Build executable
+tools\build\build_exe.bat
+
+# Build installer
+tools\build\build_installer.bat
+```
+
+See sections below for detailed explanations of each command.
+
 ## Prerequisites
 
 - Python 3.9 (project standard for local runs, GitHub workflows, and release checks)


### PR DESCRIPTION
## Summary
This PR adds organized "Quick Command Reference" sections to both CONTRIBUTING.md and docs/dev/DEVELOPER_SETUP.md to help new contributors quickly discover common commands.

## Changes
- Added categorized command groups in CONTRIBUTING.md:
  - Setup and run
  - Validation and testing
  - Building and packaging
- Added quick reference at top of DEVELOPER_SETUP.md with essential commands
- Each command includes descriptive comments

## Fixes
Fixes #5

## Definition of Done
- [x] Main contributor docs show common commands clearly
- [x] New contributors can tell how to run lint, tests, and app from docs alone
- [x] Commands are organized by purpose with comments

## Testing
Verified that all commands listed match the actual project commands from existing documentation.